### PR TITLE
Restore fine wool stat offsets

### DIFF
--- a/1.4/Defs/Resources/Wool.xml
+++ b/1.4/Defs/Resources/Wool.xml
@@ -5,25 +5,18 @@
     <defName>FineWool</defName>
     <label>fine wool</label>
     <description>Soft finely crimped wool.</description>
-    <graphicData>
-      <color>(201,192,181)</color>
-    </graphicData>
     <statBases>
       <MarketValue>4.0</MarketValue>
       <DeteriorationRate>2.6</DeteriorationRate>
+      <StuffPower_Insulation_Cold>30</StuffPower_Insulation_Cold>
+      <StuffPower_Insulation_Heat>18</StuffPower_Insulation_Heat>
     </statBases>
     <stuffProps>
       <color>(201,192,181)</color>
       <commonality>0.15</commonality>
-      <statOffsets>
-        <ArmorRating_Heat>0.05</ArmorRating_Heat>
-      </statOffsets>
-      <statFactors>
-        <ArmorRating_Sharp>1.0</ArmorRating_Sharp>
-        <ArmorRating_Heat>1.5</ArmorRating_Heat>
-        <Insulation_Cold>3.0</Insulation_Cold>
-        <Insulation_Heat>3.0</Insulation_Heat>
-      </statFactors>
     </stuffProps>
+    <graphicData>
+      <color>(201,192,181)</color>
+    </graphicData>
   </ThingDef>
 </Defs>


### PR DESCRIPTION
Presumably, because this change was before my time:

Fine wool lost its insulation factors when the syntax for defining such stat bases changed. This restores those insulation factors, tweaked to fall more in line with current vanilla wools -- specifically, heat insulation is dropped from the original 30(?) to 18.

I've only made changes to 1.4 because I don't know how far back the change was.