### PR TITLE
Make rich milk edible for babies

### DIFF
--- a/1.4/Defs/Resources/Milk.xml
+++ b/1.4/Defs/Resources/Milk.xml
@@ -25,6 +25,7 @@
     <ingestible>
       <preferability>RawTasty</preferability>
       <foodType>AnimalProduct, Fluid</foodType>
+      <babiesCanIngest>true</babiesCanIngest>
     </ingestible>
     <thingCategories>
       <li>AnimalProductRaw</li>

--- a/1.5/Defs/Resources/Milk.xml
+++ b/1.5/Defs/Resources/Milk.xml
@@ -25,6 +25,7 @@
     <ingestible>
       <preferability>RawTasty</preferability>
       <foodType>AnimalProduct, Fluid</foodType>
+      <babiesCanIngest>true</babiesCanIngest>
     </ingestible>
     <thingCategories>
       <li>AnimalProductRaw</li>


### PR DESCRIPTION
Adds `<babiesCanIngest>true</babiesCanIngest>` tag to RichMilk def to make it available for use as baby food. 